### PR TITLE
실시간 / 시간표 버튼 인터렉션 추가 #42

### DIFF
--- a/src/app/(full-layout)/transit/components/subway/RealtimeHeader.tsx
+++ b/src/app/(full-layout)/transit/components/subway/RealtimeHeader.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import clsx from 'clsx'
 
-export default function RealtimeHeader() {
-  const isLive = true
+interface RealtimeHeaderProps {
+  isLive: boolean
+  onToggle: (isLive: boolean) => void
+}
+
+export default function RealtimeHeader({ isLive, onToggle }: RealtimeHeaderProps) {
   return (
     <div className="mt-2 flex w-fit items-center justify-between rounded-full border border-gray-200">
       <button

--- a/src/app/(full-layout)/transit/components/subway/SubwayContents.tsx
+++ b/src/app/(full-layout)/transit/components/subway/SubwayContents.tsx
@@ -14,7 +14,8 @@ import { SubwayDataType } from '@/app/(full-layout)/transit/types/subwayType'
 
 export default function SubwayContents() {
   const initialActiveTab = 'all'
-
+  const [isLive2, setIsLive2] = useState(true)
+  const [isLive9, setIsLive9] = useState(true)
   const [subwayData, setSubwayData] = useState<SubwayDataType | null>(null)
   const { selected, onSelect } = useSingleSelect(initialActiveTab)
 
@@ -50,7 +51,7 @@ export default function SubwayContents() {
             {selected !== '9' && (
               <div className="flex flex-col gap-3">
                 <GroupHeader number={2} />
-                <RealtimeHeader />
+                <RealtimeHeader isLive={isLive2} onToggle={setIsLive2} />
                 <DirectionGrid grouped={groupedNum2} />
               </div>
             )}
@@ -58,7 +59,7 @@ export default function SubwayContents() {
             {selected !== '2' && (
               <div className="flex flex-col gap-3">
                 <GroupHeader number={9} />
-                <RealtimeHeader />
+                <RealtimeHeader isLive={isLive9} onToggle={setIsLive9} />
                 <DirectionGrid grouped={groupedNum9} />
               </div>
             )}


### PR DESCRIPTION
## 🚀 기능 추가 / 개선 사항
교통 페이지의 실시간 / 시간표 버튼에 인터렉션을 추가했습니다.


## 🏗 작업 내용 | 🔍 해결 방법 | 🧐 주요 변경 사항
- [x] 호선 별 isLive state 관리


## 👀 관련 이슈 번호

- #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 각 지하철 노선(2호선, 9호선)에 대해 실시간/시간표 전환 버튼이 개별적으로 동작하도록 개선되었습니다.
- **개선 사항**
  - 실시간/시간표 전환 버튼의 상태가 화면 상에서 즉시 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->