### PR TITLE
[공통] 카카오 동의항목 심사 대응 로그인 페이지 및 푸터 개인정보/이용약관 링크 추가 (#58)

### DIFF
--- a/src/app/(full-layout)/(main)/components/footer.tsx
+++ b/src/app/(full-layout)/(main)/components/footer.tsx
@@ -1,7 +1,24 @@
 export default function Footer() {
   return (
     <footer className="w-full bg-white py-6 text-left text-xs text-gray-500">
-      <div className="mx-auto max-w-screen-md space-y-1 px-4">
+      <div className="body5 mx-auto max-w-screen-md space-y-1 px-4">
+        <p className="body4-sb text-gray-600">
+          <a
+            href="https://kitworks.notion.site/kiring-privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            개인정보처리방침
+          </a>
+          <span className="px-2 text-gray-300">|</span>
+          <a
+            href="https://kitworks.notion.site/kiring-terms-of-service"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            서비스 이용약관
+          </a>
+        </p>
         <p>상호: 데이빗(주) | 대표자: 양다윗 | 사업자등록번호: 108-21-93720</p>
         <p>주소: 서울특별시 영등포구 선유서로34길 11-2 (양평동3가)</p>
         <p>이메일: didekdnlt1996@gmail.com</p>

--- a/src/app/(no-layout)/(auth)/login/components/LoginPage.tsx
+++ b/src/app/(no-layout)/(auth)/login/components/LoginPage.tsx
@@ -27,6 +27,24 @@ export default function LoginPage() {
           <br />
           회사생활에 필요한 모든 서비스를 한번에
         </div>
+
+        <p className="body4-sb mt-8 text-gray-200">
+          <a
+            href="https://kitworks.notion.site/kiring-privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            개인정보처리방침
+          </a>
+          <span className="px-2 text-gray-200">|</span>
+          <a
+            href="https://kitworks.notion.site/kiring-terms-of-service"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            서비스 이용약관
+          </a>
+        </p>
       </div>
 
       <div className="body2 w-full space-y-6">


### PR DESCRIPTION
## 🚀 기능 추가 

- 카카오 동의 항목 심사 대응 
- 로그인 / 푸터에 개인정보처리방침, 서비스 이용약관 외부 링크 추가

## 👀 관련 이슈 번호

- #58 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 푸터와 로그인 페이지에 개인정보 처리방침 및 이용약관 링크가 추가되었습니다. 두 링크 모두 새 탭에서 열리며, 보안 속성이 적용되었습니다.
- **스타일**
  - 푸터와 로그인 페이지의 링크 및 텍스트 스타일이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->