### PR TITLE
[커뮤니티] 팀 구성원 UI 구성 (#74)

### DIFF
--- a/src/app/(full-layout)/(main)/components/memberSection/MemberSection.tsx
+++ b/src/app/(full-layout)/(main)/components/memberSection/MemberSection.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image'
 import SectionHeader from '@/app/(full-layout)/(main)/components/SectionHeader'
 import { getTeamMembers } from '@/services/members'
 import TeamSelector from '@/app/(full-layout)/(main)/components/memberSection/TeamSelector'
-import { TEAMS } from '@/app/(full-layout)/(main)/constants'
+import { TEAMS } from '@/app/(full-layout)/constants'
 
 export default function MemberSection() {
   const [selectedTeam, setSelectedTeam] = useState<number>(TEAMS[0].id)

--- a/src/app/(full-layout)/(main)/constants.ts
+++ b/src/app/(full-layout)/(main)/constants.ts
@@ -1,9 +1,0 @@
-import { Team } from '@/app/(full-layout)/(main)/types/member'
-
-// 팀 목록 데이터
-export const TEAMS: Team[] = [
-  { code: 'BE', name: '백엔드팀', id: 3 },
-  { code: 'FE', name: '프론트팀', id: 4 },
-  { code: 'MG', name: '경영팀', id: 1 },
-  { code: 'PM', name: '기획팀', id: 2 },
-]

--- a/src/app/(full-layout)/(main)/page.tsx
+++ b/src/app/(full-layout)/(main)/page.tsx
@@ -2,7 +2,7 @@ import IntroSection from '@/app/(full-layout)/(main)/components/introSection/Int
 import RecommendSection from '@/app/(full-layout)/(main)/components/recommendSection/RecommendSection'
 import WeeklyScheduleSection from '@/app/(full-layout)/(main)/components/WeeklyScheduleSection'
 import MemberSection from '@/app/(full-layout)/(main)/components/memberSection/MemberSection'
-import Footer from '@/app/(full-layout)/(main)/components/Footer'
+import Footer from '@/app/(full-layout)/(main)/components/footer'
 export default function Main() {
   return (
     <div className="mx-auto flex flex-col items-center gap-3 bg-gray-50">

--- a/src/app/(full-layout)/(main)/types/member.ts
+++ b/src/app/(full-layout)/(main)/types/member.ts
@@ -23,6 +23,6 @@ export interface Member {
   employed: boolean
 }
 
-export interface TeamMembersResponse {
+export interface MembersResponse {
   members: Member[]
 }

--- a/src/app/(full-layout)/community/components/CommunityContents.tsx
+++ b/src/app/(full-layout)/community/components/CommunityContents.tsx
@@ -3,8 +3,6 @@
 import DefaultTab from '@/components/tabs/DefaultTab'
 import { useTab } from '@/components/tabs/DefaultTab/useTab'
 import MembersContents from '@/app/(full-layout)/community/components/members/MembersContents'
-import { getMemberAll } from '@/services/members'
-import { useQuery } from '@tanstack/react-query'
 
 const COMMUNITY_TABS = [
   { label: '팀 구성원', value: 'members' },

--- a/src/app/(full-layout)/community/components/CommunityContents.tsx
+++ b/src/app/(full-layout)/community/components/CommunityContents.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import DefaultTab from '@/components/tabs/DefaultTab'
+import { useTab } from '@/components/tabs/DefaultTab/useTab'
+import MembersContents from '@/app/(full-layout)/community/components/members/MembersContents'
+import { getMemberAll } from '@/services/members'
+import { useQuery } from '@tanstack/react-query'
+
+const COMMUNITY_TABS = [
+  { label: '팀 구성원', value: 'members' },
+  { label: '피드', value: 'feed' },
+]
+
+export default function CommunityContents() {
+  const initialActiveTab = 'members'
+  const { activeTab, onTabClick } = useTab(initialActiveTab)
+
+  return (
+    <>
+      <DefaultTab tabs={COMMUNITY_TABS} active={activeTab} onChange={onTabClick} />
+      <section className="mt-9">
+        {activeTab === 'members' && <MembersContents />}
+        {activeTab === 'feed' && <div>피드</div>}
+      </section>
+    </>
+  )
+}

--- a/src/app/(full-layout)/community/components/members/MembersContents.tsx
+++ b/src/app/(full-layout)/community/components/members/MembersContents.tsx
@@ -1,5 +1,7 @@
+'use client'
+
 import { MEMBERS_BUBBLES } from '@/app/(full-layout)/constants'
-import BubbleTab, { BubbleItem } from '@/components/tabs/BubbleTab'
+import BubbleTab from '@/components/tabs/BubbleTab'
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getMemberAll } from '@/services/members'
@@ -8,16 +10,23 @@ import Image from 'next/image'
 
 const MemberItem = ({ member }: { member: Member }) => {
   return (
-    <div className="flex items-center gap-2 rounded-lg bg-gray-50 p-3">
-      <Image
-        src={member.profileImageUrl}
-        alt={member.name}
-        width={40}
-        height={40}
-        className="rounded-full"
-      />
-      <div className="body2-sb text-gray-800">{member.name}</div>
-      <div className="body4 text-gray-600">{member.team.name}</div>
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-3 p-2">
+        <Image
+          src={member.profileImageUrl}
+          alt={member.name}
+          width={52}
+          height={52}
+          className="rounded-full border border-gray-300"
+        />
+        <div className="body2-sb text-basic-black">{member.name}</div>
+      </div>
+      <button
+        className="body4 text-basic-black rounded-full border border-gray-200 px-4 py-2"
+        onClick={() => console.log('paper plane to ', member.name)}
+      >
+        <span className="mb-[-2px] block">종이 비행기</span>
+      </button>
     </div>
   )
 }
@@ -42,7 +51,7 @@ export default function MembersContents() {
           onChange={handleBubbleSelect}
           propsClass="body4"
         />
-        <section className="flex flex-col bg-red-300 px-4 py-5">
+        <section className="flex h-[calc(100vh-224px)] flex-col overflow-y-auto px-4 py-5 [&::-webkit-scrollbar]:hidden">
           {selectedBubble === 'all'
             ? members?.members.map((member) => <MemberItem key={member.id} member={member} />)
             : members?.members

--- a/src/app/(full-layout)/community/components/members/MembersContents.tsx
+++ b/src/app/(full-layout)/community/components/members/MembersContents.tsx
@@ -1,0 +1,55 @@
+import { MEMBERS_BUBBLES } from '@/app/(full-layout)/constants'
+import BubbleTab, { BubbleItem } from '@/components/tabs/BubbleTab'
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getMemberAll } from '@/services/members'
+import { Member } from '@/app/(full-layout)/(main)/types/member'
+import Image from 'next/image'
+
+const MemberItem = ({ member }: { member: Member }) => {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-gray-50 p-3">
+      <Image
+        src={member.profileImageUrl}
+        alt={member.name}
+        width={40}
+        height={40}
+        className="rounded-full"
+      />
+      <div className="body2-sb text-gray-800">{member.name}</div>
+      <div className="body4 text-gray-600">{member.team.name}</div>
+    </div>
+  )
+}
+
+export default function MembersContents() {
+  const [selectedBubble, setSelectedBubble] = useState('all')
+
+  const handleBubbleSelect = (bubble: string) => {
+    setSelectedBubble(bubble)
+  }
+  const { data: members } = useQuery({
+    queryKey: ['members'],
+    queryFn: getMemberAll,
+  })
+
+  return (
+    <>
+      <div className="full-width fixed top-23 z-10 bg-white">
+        <BubbleTab
+          bubbles={MEMBERS_BUBBLES}
+          active={selectedBubble}
+          onChange={handleBubbleSelect}
+          propsClass="body4"
+        />
+        <section className="flex flex-col bg-red-300 px-4 py-5">
+          {selectedBubble === 'all'
+            ? members?.members.map((member) => <MemberItem key={member.id} member={member} />)
+            : members?.members
+                .filter((member) => member.team.code === selectedBubble)
+                .map((member) => <MemberItem key={member.id} member={member} />)}
+        </section>
+      </div>
+    </>
+  )
+}

--- a/src/app/(full-layout)/community/page.tsx
+++ b/src/app/(full-layout)/community/page.tsx
@@ -1,3 +1,11 @@
+import LoadingSpinner from '@/components/ui/LoadingSpinner'
+import { Suspense } from 'react'
+import CommunityContents from '@/app/(full-layout)/community/components/CommunityContents'
+
 export default function Community() {
-  return <div className="text-system-purple head4">Community</div>
+  return (
+    <Suspense fallback={<LoadingSpinner />}>
+      <CommunityContents />
+    </Suspense>
+  )
 }

--- a/src/app/(full-layout)/constants.ts
+++ b/src/app/(full-layout)/constants.ts
@@ -1,0 +1,18 @@
+import { Team } from '@/app/(full-layout)/(main)/types/member'
+import { BubbleItem } from '@/components/tabs/BubbleTab'
+
+// 팀 목록 데이터
+export const TEAMS: Team[] = [
+  { code: 'BE', name: '백엔드팀', id: 3 },
+  { code: 'FE', name: '프론트팀', id: 4 },
+  { code: 'MG', name: '경영팀', id: 1 },
+  { code: 'PM', name: '기획팀', id: 2 },
+]
+
+export const MEMBERS_BUBBLES: BubbleItem[] = [
+  { label: '전체', value: 'all' },
+  { label: '백엔드팀', value: 'BE' },
+  { label: '프론트팀', value: 'FE' },
+  { label: '경영팀', value: 'MG' },
+  { label: '기획팀', value: 'PM' },
+]

--- a/src/components/layout/Navigation/index.tsx
+++ b/src/components/layout/Navigation/index.tsx
@@ -9,7 +9,10 @@ export default function Navigation() {
   const router = useRouter()
 
   return (
-    <nav aria-label="메인 네비게이션" className="nav-shadow full-width fixed bottom-0 h-18 px-6">
+    <nav
+      aria-label="메인 네비게이션"
+      className="nav-shadow full-width fixed bottom-0 z-10 h-18 px-6"
+    >
       <div className="flex h-full w-full justify-between">
         {NAV_BUTTONS.map(({ title, icon: Icon, endpoint }) => {
           // 홈('/')의 경우 정확히 일치할 때만 활성화

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,5 +21,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/login', '/login/callback', '/mypage/:path*', '/community/:path*'],
+  matcher: ['/login', '/login/callback', '/mypage/:path*'],
 }

--- a/src/services/members.ts
+++ b/src/services/members.ts
@@ -1,6 +1,10 @@
 import ApiClient from '@/lib/api/client'
-import { TeamMembersResponse } from '@/app/(full-layout)/(main)/types/member'
+import { MembersResponse } from '@/app/(full-layout)/(main)/types/member'
 
-export const getTeamMembers = (teamId: number): Promise<TeamMembersResponse> => {
+export const getTeamMembers = (teamId: number): Promise<MembersResponse> => {
   return ApiClient.get(`/member/teams/members?teamId=${teamId}`)
+}
+
+export const getMemberAll = (): Promise<MembersResponse> => {
+  return ApiClient.get('/member/all')
 }


### PR DESCRIPTION
## 🚀 기능 추가 / 개선 사항
커뮤니티 페이지의 팀구성원 탭 UI를 구성하는 작업을 진행했습니다.

<img width="489" alt="스크린샷 2025-06-14 00 30 09" src="https://github.com/user-attachments/assets/88c081c5-4d58-465d-9d6d-4bffb3654a3f" />

## 🏗 작업 내용 

- [x] 팀 구성원 UI 구성
- [x] 전체 멤버 조회 api 호출

## 👀 관련 이슈 번호

- #74 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 커뮤니티 페이지에 "팀 구성원"과 "피드" 탭이 있는 탭 인터페이스가 추가되었습니다.
  - 팀별 필터링이 가능한 구성원 목록과 "종이 비행기" 버튼 기능이 추가되었습니다.

- **버그 수정**
  - 일부 경로 및 타입명 변경으로 인한 내부 일관성 개선이 이루어졌습니다.

- **리팩터**
  - 상수 및 타입 선언 위치가 정리되어 유지보수성이 향상되었습니다.

- **기타**
  - 커뮤니티 경로에 대한 미들웨어 적용이 해제되었습니다.
  - 네비게이션 레이아웃의 z-index가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->