### PR TITLE
[공통] 로그인 시 내 정보 전역 관리 & 토큰 유효성 검사 (#83)

### DIFF
--- a/src/app/(header-layout)/mypage/components/MypageContent.tsx
+++ b/src/app/(header-layout)/mypage/components/MypageContent.tsx
@@ -2,31 +2,21 @@
 
 import { useRouter } from 'next/navigation'
 import { useAuthStore } from '@/stores/login'
-import { useQuery } from '@tanstack/react-query'
-import { getMemberMe } from '@/services/member'
-import { MemberMeType } from '@/app/types/memberType'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import PlaneSection from '@/app/(header-layout)/mypage/components/plane/PlaneSection'
 import MemberInfoSection from '@/app/(header-layout)/mypage/components/memberinfo/MemberInfoSection'
 import ProfileSection from '@/app/(header-layout)/mypage/components/profile/ProfileSection'
 import { useEffect } from 'react'
+import { useUser } from '@/stores/user'
 
 export default function MyPageContent() {
   const router = useRouter()
   const { isLogin, setLogout } = useAuthStore()
-
-  const { data, isLoading, isError } = useQuery<{ member: MemberMeType }>({
-    queryKey: ['memberMe'],
-    queryFn: getMemberMe,
-    refetchOnWindowFocus: false,
-    enabled: isLogin,
-  })
+  const { user, isLoading, isError } = useUser()
 
   useEffect(() => {
     if (isError) router.push('/error')
   }, [isError, router])
-
-  const user = data?.member
 
   // ✅ 로그아웃 시 토큰 삭제
   const handleLogout = () => {

--- a/src/app/(header-layout)/mypage/components/MypageContent.tsx
+++ b/src/app/(header-layout)/mypage/components/MypageContent.tsx
@@ -2,41 +2,31 @@
 
 import { useRouter } from 'next/navigation'
 import { useAuthStore } from '@/stores/login'
-import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import PlaneSection from '@/app/(header-layout)/mypage/components/plane/PlaneSection'
 import MemberInfoSection from '@/app/(header-layout)/mypage/components/memberinfo/MemberInfoSection'
 import ProfileSection from '@/app/(header-layout)/mypage/components/profile/ProfileSection'
-import { useEffect } from 'react'
-import { useUser } from '@/stores/user'
+import { useUserStore } from '@/stores/user'
 
 export default function MyPageContent() {
   const router = useRouter()
   const { isLogin, setLogout } = useAuthStore()
-  const { user, isLoading, isError } = useUser()
+  const { user, clearUser } = useUserStore()
 
-  useEffect(() => {
-    if (isError) router.push('/error')
-  }, [isError, router])
-
-  // ✅ 로그아웃 시 토큰 삭제
+  // ✅ 로그아웃 시 토큰 / 유저정보 삭제
   const handleLogout = () => {
     setLogout()
+    clearUser()
     router.replace(`${process.env.NEXT_PUBLIC_API_URL}/auth/logout`)
   }
 
   return (
     <>
-      {(isLoading || !user) && (
-        <>
-          <section className="nav-pd h-full">
-            {isLoading && <LoadingSpinner />}
-            {!isLoading && isLogin && !user && (
-              <p className="flex-row-center body3 h-full text-gray-800">
-                사용자 정보를 조회할 수 없습니다.
-              </p>
-            )}
-          </section>
-        </>
+      {isLogin && !user && (
+        <section className="nav-pd h-full">
+          <p className="flex-row-center body3 h-full text-gray-800">
+            사용자 정보를 조회할 수 없습니다.
+          </p>
+        </section>
       )}
       {user && (
         <div className="flex flex-col gap-6">

--- a/src/app/(header-layout)/mypage/components/memberinfo/MemberInfoSection.tsx
+++ b/src/app/(header-layout)/mypage/components/memberinfo/MemberInfoSection.tsx
@@ -2,11 +2,7 @@ import { MemberMeType } from '@/app/types/memberType'
 import dayjs from 'dayjs'
 import MemberInfoItem from '@/app/(header-layout)/mypage/components/memberinfo/MemberInfoItem'
 
-interface MemberInfoSectionProps {
-  user: MemberMeType
-}
-
-export default function MemberInfoSection({ user }: MemberInfoSectionProps) {
+export default function MemberInfoSection({ user }: { user: MemberMeType }) {
   return (
     <section className="container px-4">
       <div className="head5">

--- a/src/app/(header-layout)/mypage/components/plane/PlaneMessageCard.tsx
+++ b/src/app/(header-layout)/mypage/components/plane/PlaneMessageCard.tsx
@@ -2,13 +2,10 @@
 
 import Image from 'next/image'
 import IcoPlane from '@/assets/ico-plane.svg'
-import { PlaneMessage } from '@/app/(header-layout)/mypage/constants'
+import { PlaneMessage } from '@/app/(header-layout)/mypage/types/plane'
 import { formatRelativeTime } from '@/utils/date'
-interface PlaneMessageCardProps {
-  plane: PlaneMessage
-}
 
-export default function PlaneMessageCard({ plane }: PlaneMessageCardProps) {
+export default function PlaneMessageCard({ plane }: { plane: PlaneMessage }) {
   return (
     <li className="flex h-56 w-80 flex-col justify-between rounded-xl border bg-white p-5">
       <p className="body2 line-clamp-4 text-gray-800">{plane?.message}</p>

--- a/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
+++ b/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
@@ -1,28 +1,61 @@
 import PlaneMessageCard from '@/app/(header-layout)/mypage/components/plane/PlaneMessageCard'
+import { useQuery } from '@tanstack/react-query'
+import { getPlaneRead } from '@/services/plane'
+import { useAuthStore } from '@/stores/login'
+import { PlaneMessage } from '../../types/plane'
+import LoadingSpinner from '@/components/ui/LoadingSpinner'
 
 export default function PlaneSection() {
+  const { isLogin } = useAuthStore()
+  const { data, isLoading } = useQuery<PlaneMessage[]>({
+    queryKey: ['planeRead'],
+    queryFn: getPlaneRead,
+    refetchOnWindowFocus: false,
+    enabled: isLogin,
+  })
+  const planeMessages = data ?? []
+  const debugEmpty = false
+
   return (
     <section className="container">
       <div className="head5 px-4">
         <p className="text-black">내가 받은 종이비행기</p>
       </div>
 
-      <div className="scroll-hidden mt-4 flex gap-4 overflow-x-scroll px-4">
-        <ul className="flex gap-4">
-          {planeMessages.map((plane) => (
-            <PlaneMessageCard key={plane?.messageId} plane={plane} />
-          ))}
-        </ul>
-      </div>
+      {isLoading && (
+        <section className="h-full p-20">
+          <LoadingSpinner />
+        </section>
+      )}
 
-      <div className="px-4">
-        <button
-          type="button"
-          className="flex-row-center body4 mt-6 w-full gap-3 rounded-xl border border-black px-4 py-4 text-black"
-        >
-          종이비행기 {planeMessages.length}개 모두 보기
-        </button>
-      </div>
+      {isLoading && isLogin && planeMessages.length === 0 && (
+        <section className="nav-pd h-full">
+          <p className="flex-row-center body3 h-full text-gray-800">
+            종이 비행기를 조회할 수 없습니다.
+          </p>
+        </section>
+      )}
+
+      {!isLoading && planeMessages.length > 0 && (
+        <>
+          <div className="mt-4 flex gap-4 overflow-x-scroll px-4 [&::-webkit-scrollbar]:hidden">
+            <ul className="flex gap-4">
+              {planeMessages.map((plane: PlaneMessage) => (
+                <PlaneMessageCard key={plane.messageId} plane={plane} />
+              ))}
+            </ul>
+          </div>
+
+          <div className="px-4">
+            <button
+              type="button"
+              className="flex-row-center body4 mt-6 w-full gap-3 rounded-xl border border-black px-4 py-4 text-black"
+            >
+              종이비행기 {planeMessages.length}개 모두 보기
+            </button>
+          </div>
+        </>
+      )}
     </section>
   )
 }

--- a/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
+++ b/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
@@ -27,7 +27,7 @@ export default function PlaneSection() {
         </section>
       )}
 
-      {isLoading && isLogin && planeMessages.length === 0 && (
+      {!isLoading && isLogin && planeMessages.length === 0 && (
         <section className="nav-pd h-full">
           <p className="flex-row-center body3 h-full text-gray-800">
             종이 비행기를 조회할 수 없습니다.

--- a/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
+++ b/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
@@ -1,4 +1,3 @@
-import { planeMessages } from '@/app/(header-layout)/mypage/constants'
 import PlaneMessageCard from '@/app/(header-layout)/mypage/components/plane/PlaneMessageCard'
 
 export default function PlaneSection() {

--- a/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
+++ b/src/app/(header-layout)/mypage/components/plane/PlaneSection.tsx
@@ -2,7 +2,7 @@ import PlaneMessageCard from '@/app/(header-layout)/mypage/components/plane/Plan
 import { useQuery } from '@tanstack/react-query'
 import { getPlaneRead } from '@/services/plane'
 import { useAuthStore } from '@/stores/login'
-import { PlaneMessage } from '../../types/plane'
+import { PlaneMessage } from '@/app/(header-layout)/mypage/types/plane'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 
 export default function PlaneSection() {
@@ -14,7 +14,6 @@ export default function PlaneSection() {
     enabled: isLogin,
   })
   const planeMessages = data ?? []
-  const debugEmpty = false
 
   return (
     <section className="container">

--- a/src/app/(header-layout)/mypage/types/plane.ts
+++ b/src/app/(header-layout)/mypage/types/plane.ts
@@ -1,0 +1,12 @@
+export interface PlaneMessage {
+  messageId: number
+  sender: PlaneSender
+  message: string
+  sentAt: string
+}
+
+export interface PlaneSender {
+  id: number
+  name: string
+  profileImageUrl: string
+}

--- a/src/app/(no-layout)/(auth)/login/callback/components/LoginCallbackPage.tsx
+++ b/src/app/(no-layout)/(auth)/login/callback/components/LoginCallbackPage.tsx
@@ -6,17 +6,20 @@ import { useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import { useAuthStore } from '@/stores/login'
+import { getMemberMe } from '@/services/member'
+import { useUserStore } from '@/stores/user'
 
 export default function LoginCallbackPage() {
   const router = useRouter()
   const { setLogin } = useAuthStore()
+  const { setUser } = useUserStore()
   const searchParams = useSearchParams()
 
-  useEffect(() => {
-    const accessToken = searchParams.get('accessToken')
-    const refreshToken = searchParams.get('refreshToken')
-    const errorCode = searchParams.get('errorCode')
+  const accessToken = searchParams.get('accessToken')
+  const refreshToken = searchParams.get('refreshToken')
+  const errorCode = searchParams.get('errorCode')
 
+  useEffect(() => {
     // 에러 처리
     if (errorCode) {
       const loginUrl = new URL('/login', window.location.origin)
@@ -33,17 +36,22 @@ export default function LoginCallbackPage() {
 
     // 로그인 성공 시 쿠키 저장
     setLogin(accessToken, refreshToken)
+  }, [accessToken, refreshToken, errorCode, router, setLogin])
 
-    // 첫 로그인시 환영 페이지로 리다이렉트
-    const isWelcomeShown = localStorage.getItem('welcomeShown')
-    if (!isWelcomeShown) {
-      router.replace('/welcome')
-      return
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const { member } = await getMemberMe()
+        setUser(member)
+        router.replace('/')
+      } catch (e) {
+        console.error('❌ 유저 정보 조회 실패', e)
+        router.replace('/login')
+      }
     }
 
-    // 로그인 성공시 홈으로 리다이렉트
-    router.replace('/')
-  }, [searchParams, router])
+    fetchUser()
+  }, [accessToken, refreshToken, router, setUser])
 
   return (
     <div className="flex h-screen items-center justify-center bg-white">

--- a/src/app/(no-layout)/(auth)/welcome/components/WelcomePage.tsx
+++ b/src/app/(no-layout)/(auth)/welcome/components/WelcomePage.tsx
@@ -5,13 +5,13 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import clsx from 'clsx'
 import WelcomeEffect from '@/app/(no-layout)/(auth)/welcome/components/WelcomeEffect'
-import { useQuery } from '@tanstack/react-query'
-import { getMemberMe } from '@/services/member'
-import { MemberMeType } from '@/app/types/memberType'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
+import { useUser } from '@/stores/user'
 
 export default function WelcomePage() {
   const router = useRouter()
+  const { user, isLoading, isError } = useUser()
+
   const [isAuthChecked, setIsAuthChecked] = useState(false)
   const [showAnimation, setShowAnimation] = useState(false)
 
@@ -25,18 +25,11 @@ export default function WelcomePage() {
     setIsAuthChecked(true)
   }, [router])
 
-  const { data, isLoading, isError } = useQuery<{ member: MemberMeType }>({
-    queryKey: ['memberMe'],
-    queryFn: getMemberMe,
-    refetchOnWindowFocus: false,
-  })
-
-  const debugEmpty = false // 디버그용, 실제 배포 시에는 false로 설정
-  const user = !debugEmpty ? data?.member : null
-
-  if (isError) {
-    router.push('/error')
-  }
+  useEffect(() => {
+    if (isError) {
+      router.push('/error')
+    }
+  }, [isError, router])
 
   useEffect(() => {
     if (user && !localStorage.getItem('welcomeShown')) {

--- a/src/app/(no-layout)/(auth)/welcome/components/WelcomePage.tsx
+++ b/src/app/(no-layout)/(auth)/welcome/components/WelcomePage.tsx
@@ -5,15 +5,15 @@ import { useEffect, useState } from 'react'
 import Image from 'next/image'
 import clsx from 'clsx'
 import WelcomeEffect from '@/app/(no-layout)/(auth)/welcome/components/WelcomeEffect'
+import { useUserStore } from '@/stores/user'
 import LoadingSpinner from '@/components/ui/LoadingSpinner'
-import { useUser } from '@/stores/user'
 
 export default function WelcomePage() {
   const router = useRouter()
-  const { user, isLoading, isError } = useUser()
+  const { user } = useUserStore()
 
-  const [isAuthChecked, setIsAuthChecked] = useState(false)
   const [showAnimation, setShowAnimation] = useState(false)
+  const [redirectHandled, setRedirectHandled] = useState(false)
 
   useEffect(() => {
     const isWelcomeShown = localStorage.getItem('welcomeShown')
@@ -22,92 +22,83 @@ export default function WelcomePage() {
       return
     }
 
-    setIsAuthChecked(true)
-  }, [router])
+    router.prefetch('/')
+    router.prefetch('/mypage')
 
-  useEffect(() => {
-    if (isError) {
-      router.push('/error')
-    }
-  }, [isError, router])
-
-  useEffect(() => {
-    if (user && !localStorage.getItem('welcomeShown')) {
-      localStorage.setItem('welcomeShown', 'true')
+    if (user) {
       setTimeout(() => setShowAnimation(true))
     }
-  }, [user])
+
+    setRedirectHandled(true)
+  }, [router, user])
 
   const handleMypage = () => {
+    localStorage.setItem('welcomeShown', 'true')
     router.push('/mypage')
+  }
+
+  const handleHome = () => {
+    localStorage.setItem('welcomeShown', 'true')
+    router.push('/')
+  }
+
+  if (!redirectHandled) {
+    return <LoadingSpinner />
   }
 
   return (
     <>
-      {!isAuthChecked || isLoading ? (
-        <LoadingSpinner />
+      {!user ? (
+        <div className="flex-row-center body3 h-full text-gray-800">
+          사용자 정보를 조회할 수 없습니다.
+        </div>
       ) : (
-        <>
-          {!user ? (
-            <div className="flex-row-center body3 h-full text-gray-800">
-              사용자 정보를 조회할 수 없습니다.
+        <div className="relative flex h-full w-full flex-col items-center justify-between overflow-hidden bg-gradient-to-b from-purple-300 to-purple-600 px-4 py-10 text-white">
+          <div className="flex-col-center z-10 mt-22 flex w-full max-w-md gap-6">
+            <div className={clsx('head2 effect-name', showAnimation && 'fade-name')}>
+              {user?.name}님
             </div>
-          ) : (
-            <div className="relative flex h-full w-full flex-col items-center justify-between overflow-hidden bg-gradient-to-b from-purple-300 to-purple-600 px-4 py-10 text-white">
-              <div className="flex-col-center z-10 mt-22 flex w-full max-w-md gap-6">
-                <div className={clsx('head2 effect-name', showAnimation && 'fade-name')}>
-                  {user?.name}님
-                </div>
-                <div
-                  className={clsx(
-                    'head5 effect-welcome text-white',
-                    showAnimation && 'fade-welcome',
-                  )}
-                >
-                  키링에 오신걸 환영해요, 당신과 함께할 키링이에요!
-                </div>
-              </div>
-
-              {/* 키링 이미지 */}
-              <div
-                className={clsx(
-                  'effect-profile relative z-10',
-                  showAnimation && 'fade-scale-profile float-profile',
-                )}
-              >
-                <Image
-                  src={user?.kiringImageUrl ?? '/default-kiring.png'}
-                  alt="사용자 프로필"
-                  width={320}
-                  height={320}
-                  className="mx-auto rotate-10 rounded-full"
-                  priority
-                />
-              </div>
-
-              <div className="body2 z-10 w-full space-y-6">
-                <button
-                  type="button"
-                  onClick={handleMypage}
-                  className="flex-row-center w-full gap-3 rounded-xl bg-white px-4 py-4 text-purple-500"
-                >
-                  내 프로필 보러가기
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => router.push('/')}
-                  className="w-full text-white/90 underline"
-                >
-                  나중에
-                </button>
-              </div>
-
-              {/* 애니메이션 효과 */}
-              {showAnimation && <WelcomeEffect />}
+            <div
+              className={clsx('head5 effect-welcome text-white', showAnimation && 'fade-welcome')}
+            >
+              키링에 오신걸 환영해요, 당신과 함께할 키링이에요!
             </div>
-          )}
-        </>
+          </div>
+
+          {/* 키링 이미지 */}
+          <div
+            className={clsx(
+              'effect-profile relative z-10',
+              showAnimation && 'fade-scale-profile float-profile',
+            )}
+          >
+            <Image
+              src={user?.kiringImageUrl ?? '/default-kiring.png'}
+              alt="사용자 프로필"
+              width={320}
+              height={320}
+              className="mx-auto rotate-10 rounded-full"
+              priority
+            />
+          </div>
+
+          <div className="body2 z-10 w-full space-y-6">
+            <button
+              type="button"
+              onClick={handleMypage}
+              className="flex-row-center w-full gap-3 rounded-xl bg-white px-4 py-4 text-purple-500"
+            >
+              내 프로필 보러가기
+            </button>
+
+            <button type="button" onClick={handleHome} className="w-full text-white/90 underline">
+              나중에
+            </button>
+          </div>
+
+          {/* 애니메이션 효과 */}
+          {showAnimation && <WelcomeEffect />}
+        </div>
       )}
     </>
   )

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,30 +1,19 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { SessionProvider } from 'next-auth/react'
-import { useAuthStore } from '@/stores/login'
-import { usePathname, useRouter } from 'next/navigation'
+import AuthProvider from '@/components/auth/AuthProvider'
 
 export const Providers = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient())
-  const pathname = usePathname()
-  const router = useRouter()
-  const { isLogin } = useAuthStore()
-
-  useEffect(() => {
-    // 로그인 상태 체크
-    useAuthStore.getState().checkToken()
-    const user = localStorage.getItem('kiring-user')
-    if (isLogin && !user) {
-      useAuthStore.getState().setLogout()
-      router.push('/login')
-    }
-  }, [pathname, router])
 
   return (
     <SessionProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider />
+        {children}
+      </QueryClientProvider>
     </SessionProvider>
   )
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,15 +4,23 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode, useEffect, useState } from 'react'
 import { SessionProvider } from 'next-auth/react'
 import { useAuthStore } from '@/stores/login'
-import { usePathname } from 'next/navigation'
+import { usePathname, useRouter } from 'next/navigation'
 
 export const Providers = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient())
   const pathname = usePathname()
+  const router = useRouter()
+  const { isLogin } = useAuthStore()
+
   useEffect(() => {
     // 로그인 상태 체크
     useAuthStore.getState().checkToken()
-  }, [pathname])
+    const user = localStorage.getItem('kiring-user')
+    if (isLogin && !user) {
+      useAuthStore.getState().setLogout()
+      router.push('/login')
+    }
+  }, [pathname, router])
 
   return (
     <SessionProvider>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -4,14 +4,18 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactNode, useEffect, useState } from 'react'
 import { SessionProvider } from 'next-auth/react'
 import { useAuthStore } from '@/stores/login'
+import { usePathname } from 'next/navigation'
 
 export const Providers = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient())
-
+  const pathname = usePathname()
+  const { isLogin } = useAuthStore()
   useEffect(() => {
     // 로그인 상태 체크
     useAuthStore.getState().checkToken()
-  }, [])
+    console.log('🚀 ~ Providers ~ pathname:', pathname)
+    console.log('🚀 ~ Providers ~ pathname:', isLogin)
+  }, [pathname, isLogin])
 
   return (
     <SessionProvider>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -9,13 +9,10 @@ import { usePathname } from 'next/navigation'
 export const Providers = ({ children }: { children: ReactNode }) => {
   const [queryClient] = useState(() => new QueryClient())
   const pathname = usePathname()
-  const { isLogin } = useAuthStore()
   useEffect(() => {
     // 로그인 상태 체크
     useAuthStore.getState().checkToken()
-    console.log('🚀 ~ Providers ~ pathname:', pathname)
-    console.log('🚀 ~ Providers ~ pathname:', isLogin)
-  }, [pathname, isLogin])
+  }, [pathname])
 
   return (
     <SessionProvider>

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -1,0 +1,34 @@
+import { getMemberMe } from '@/services/member'
+import { useAuthStore } from '@/stores/login'
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import { useUserStore } from '@/stores/user'
+export default function AuthProvider() {
+  const pathname = usePathname()
+  const router = useRouter()
+
+  useEffect(() => {
+    //쿠키 기반으로 isLogin 여부 갱신
+    useAuthStore.getState().checkToken()
+
+    const user = localStorage.getItem('kiring-user')
+    const isLogin = useAuthStore.getState().isLogin
+
+    // 로그인 상태인데 유저 정보 없을 때 -> api 호출 동기화
+    if (isLogin && !user) {
+      const fetchUser = async () => {
+        try {
+          const { member } = await getMemberMe()
+          useUserStore.getState().setUser(member)
+        } catch (e) {
+          console.error('❌ 유저 정보 조회 실패', e)
+          router.replace('/login')
+        }
+      }
+
+      fetchUser()
+    }
+  }, [pathname, router])
+
+  return null
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,7 @@ export async function middleware(request: NextRequest) {
   let isAuthenticated = false
   let shouldRemoveCookies = false
 
-  // 인증 검사
+  // 내 정보 API 호출로 accessToken 유효성 확인
   try {
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/member/me`, {
       headers: {
@@ -20,37 +20,32 @@ export async function middleware(request: NextRequest) {
 
     if (result.result === 'SUCCESS') {
       isAuthenticated = true
-      console.log('✅ 인증 성공:', result.data)
     } else {
-      console.log('❌ 인증 실패:', result.message)
       shouldRemoveCookies = true
     }
   } catch (error) {
-    console.error('❌ 인증 fetch 에러:', error)
     shouldRemoveCookies = true
   }
 
-  const isLoginPage = new Set(['/login', '/login/callback']).has(pathname)
+  const isLoginPage = ['/login', '/login/callback'].includes(pathname)
   const isProtectedPage = ['/mypage', '/community'].some((prefix) => pathname.startsWith(prefix))
 
-  // 리다이렉트 응답 생성
+  // 1. 로그인된 사용자가 로그인 페이지 접근 → 홈으로 리디렉트
   if (isAuthenticated && isLoginPage) {
-    const res = NextResponse.redirect(new URL('/', request.url))
-    if (shouldRemoveCookies) {
-      res.cookies.delete('accessToken')
-      res.cookies.delete('refreshToken')
-      console.log('🧹 쿠키 삭제됨 (홈 리디렉트)')
-    }
-    return res
+    return NextResponse.redirect(new URL('/', request.url))
   }
 
+  // 2. 비로그인 사용자가 보호 페이지 접근 → 로그인 페이지로 리디렉트
   if (!isAuthenticated && isProtectedPage) {
-    const res = NextResponse.redirect(new URL('/login', request.url))
-    if (shouldRemoveCookies) {
-      res.cookies.delete('accessToken')
-      res.cookies.delete('refreshToken')
-      console.log('🧹 쿠키 삭제됨 (로그인 리디렉트)')
-    }
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  // 3. 유효성 검사 실패 시 → 토큰 삭제 및 상태 정리 (CSR에서 checkToken 실행)
+  if (shouldRemoveCookies) {
+    const res = NextResponse.next()
+    res.cookies.delete('accessToken')
+    res.cookies.delete('refreshToken')
+    // 응답 브라우저에 전달
     return res
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -24,6 +24,7 @@ export async function middleware(request: NextRequest) {
       shouldRemoveCookies = true
     }
   } catch (error) {
+    console.log('❌ Token 유효성 error:', error)
     shouldRemoveCookies = true
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,28 +1,60 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { isLikelyValidToken } from '@/lib/jwt'
 
-export function middleware(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get('accessToken')?.value
   const { pathname } = request.nextUrl
+
+  let isAuthenticated = false
+  let shouldRemoveCookies = false
+
+  // 인증 검사
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/member/me`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    })
+
+    const result = await res.json()
+
+    if (result.result === 'SUCCESS') {
+      isAuthenticated = true
+      console.log('✅ 인증 성공:', result.data)
+    } else {
+      console.log('❌ 인증 실패:', result.message)
+      shouldRemoveCookies = true
+    }
+  } catch (error) {
+    console.error('❌ 인증 fetch 에러:', error)
+    shouldRemoveCookies = true
+  }
 
   const isLoginPage = new Set(['/login', '/login/callback']).has(pathname)
   const isProtectedPage = ['/mypage', '/community'].some((prefix) => pathname.startsWith(prefix))
 
-  // 토큰 존재 여부와 유효성 모두 검증
-  const isAuthenticated = accessToken ? isLikelyValidToken(accessToken) : false
-
-  // 1. 로그인 완료 후 로그인/콜백 페이지 접근 시 → 홈으로
+  // 리다이렉트 응답 생성
   if (isAuthenticated && isLoginPage) {
-    return NextResponse.redirect(new URL('/', request.url))
+    const res = NextResponse.redirect(new URL('/', request.url))
+    if (shouldRemoveCookies) {
+      res.cookies.delete('accessToken')
+      res.cookies.delete('refreshToken')
+      console.log('🧹 쿠키 삭제됨 (홈 리디렉트)')
+    }
+    return res
   }
 
-  // 2. 로그인 전 보호 페이지 접근 시 → 로그인으로
   if (!isAuthenticated && isProtectedPage) {
-    return NextResponse.redirect(new URL('/login', request.url))
+    const res = NextResponse.redirect(new URL('/login', request.url))
+    if (shouldRemoveCookies) {
+      res.cookies.delete('accessToken')
+      res.cookies.delete('refreshToken')
+      console.log('🧹 쿠키 삭제됨 (로그인 리디렉트)')
+    }
+    return res
   }
-  return NextResponse.next()
 }
 
 export const config = {
-  matcher: ['/login', '/login/callback', '/mypage/:path*', '/community/:path*'],
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 }

--- a/src/services/plane.ts
+++ b/src/services/plane.ts
@@ -1,0 +1,6 @@
+import ApiClient from '@/lib/api/client'
+import { PlaneMessage } from '@/app/(header-layout)/mypage/types/plane'
+
+export const getPlaneRead = (): Promise<PlaneMessage[]> => {
+  return ApiClient.get('/plane/read')
+}

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import Cookies from 'js-cookie'
-
+import { useUserStore } from '@/stores/user'
 interface AuthState {
   isLogin: boolean
   setLogin: (accessToken: string, refreshToken: string) => void
@@ -28,7 +28,7 @@ export const useAuthStore = create<AuthState>()(
 
       checkToken: () => {
         const token = Cookies.get('accessToken')
-        set({ isLogin: token ? true : false })
+        set({ isLogin: !!token })
       },
     }),
     {

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import Cookies from 'js-cookie'
-import { isLikelyValidToken } from '@/lib/jwt'
 
 interface AuthState {
   isLogin: boolean
@@ -29,7 +28,8 @@ export const useAuthStore = create<AuthState>()(
 
       checkToken: () => {
         const token = Cookies.get('accessToken')
-        set({ isLogin: token ? isLikelyValidToken(token) : false })
+        console.log('🚀 ~ token:', token)
+        set({ isLogin: token ? true : false })
       },
     }),
     {

--- a/src/stores/login.ts
+++ b/src/stores/login.ts
@@ -28,7 +28,6 @@ export const useAuthStore = create<AuthState>()(
 
       checkToken: () => {
         const token = Cookies.get('accessToken')
-        console.log('🚀 ~ token:', token)
         set({ isLogin: token ? true : false })
       },
     }),

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query'
+import { getMemberMe } from '@/services/member'
+import { MemberMeType } from '@/app/types/memberType'
+import { useAuthStore } from '@/stores/login'
+
+export const useUser = () => {
+  const { isLogin } = useAuthStore()
+
+  const query = useQuery<{ member: MemberMeType }>({
+    queryKey: ['memberMe'],
+    queryFn: getMemberMe,
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 5,
+    enabled: isLogin,
+  })
+
+  return {
+    user: query.data?.member,
+    ...query,
+  }
+}

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,21 +1,23 @@
-import { useQuery } from '@tanstack/react-query'
-import { getMemberMe } from '@/services/member'
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import { MemberMeType } from '@/app/types/memberType'
-import { useAuthStore } from '@/stores/login'
 
-export const useUser = () => {
-  const { isLogin } = useAuthStore()
-
-  const query = useQuery<{ member: MemberMeType }>({
-    queryKey: ['memberMe'],
-    queryFn: getMemberMe,
-    refetchOnWindowFocus: false,
-    staleTime: 1000 * 60 * 5,
-    enabled: isLogin,
-  })
-
-  return {
-    user: query.data?.member,
-    ...query,
-  }
+interface UserState {
+  user: MemberMeType | null
+  setUser: (user: MemberMeType) => void
+  clearUser: () => void
 }
+
+export const useUserStore = create<UserState>()(
+  persist(
+    (set) => ({
+      user: null,
+      setUser: (user) => set({ user }),
+      clearUser: () => set({ user: null }),
+    }),
+    {
+      name: 'kiring-user',
+      partialize: (state) => ({ user: state.user }),
+    },
+  ),
+)


### PR DESCRIPTION
## 🚀 기능 추가
•	middleware.ts에서 /api/v1/member/me API를 활용해 accessToken 유효성 검사 로직 추가
•	인증 실패 시 서버에서 accessToken, refreshToken 쿠키 삭제 후 클라이언트 상태 정리
•	클라이언트 providers.tsx에서 pathname 변경 시 checkToken() 실행하여 로그인 상태 갱신
•	종이비행기 API 연동 및 관련 기능 일부 추가 (#77 이슈 작업 중 일부 반영)

## 🏗 작업 내용

###  middleware.ts
•	내 정보 조회 API (/member/me) 호출을 통한 토큰 유효성 검사 
•	인증 실패 시 NextResponse.next()로 응답 전달하며, 쿠키 제거 처리 (accessToken, refreshToken) 후 브라우저에 반영
•	로그인/보호 페이지 접근에 따라 조건 분기 리디렉션 처리

###  useAuthStore
•	CSR에서 checkToken() 함수로 로그인 상태 동기화 (쿠키 기반)
•       providers.tsx에서 pathname 변경 시 checkToken() 실행
→ 쿠키 유무 기반으로 isLogin 상태를 최신화하여 CSR에서 인증 상태 반영

### useUser.ts
•	전역 사용자 정보 상태 관리를 위한 커스텀 훅 추가
•	useQuery로 getMemberMe API 호출 → 로그인된 사용자 정보 사용


##  🔮 향후 계획
- 토큰 만료 시 자동 재발급 또는 재조회 API (/auth/refresh 등) 연동 예정

## 👀 관련 이슈 번호

- #83 #77 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사용자 정보를 관리하는 상태 저장소(useUserStore)가 도입되었습니다.
  - Plane 메시지 목록을 서버에서 비동기로 불러오는 기능이 도입되었습니다.
  - Plane 메시지 및 발신자 타입이 새롭게 정의되었습니다.
  - Plane 메시지 조회 API 서비스가 추가되었습니다.
  - 인증 상태 관리를 위한 AuthProvider 컴포넌트가 추가되었습니다.

- **버그 수정**
  - 마이페이지 및 웰컴 페이지에서 사용자 정보 로딩 및 오류 처리 방식이 개선되었습니다.

- **리팩터링**
  - Plane 메시지, 사용자 정보 등 일부 컴포넌트의 타입 선언 방식이 간소화되었습니다.
  - Plane 메시지 목록 렌더링 로직이 비동기 데이터 흐름에 맞게 개선되었습니다.
  - 로그인 콜백 및 웰컴 페이지의 사용자 상태 처리 로직이 정리되었습니다.
  - 인증 미들웨어가 API 기반 토큰 검증으로 변경되어 보안성이 강화되었습니다.
  - 로그인 상태 체크가 토큰 존재 여부만으로 단순화되었습니다.
  - 라우트 변경 시 로그인 상태가 다시 확인되도록 변경되었습니다.

- **기타**
  - Providers 컴포넌트에 AuthProvider가 포함되어 인증 관리가 통합되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->