### PR TITLE
[공통] 미들웨어 로그인/액세스 토큰 검증 시 방어 로직 추가 (#83)

### DIFF
--- a/src/app/(no-layout)/(auth)/login/callback/components/LoginCallbackPage.tsx
+++ b/src/app/(no-layout)/(auth)/login/callback/components/LoginCallbackPage.tsx
@@ -8,6 +8,7 @@ import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import { useAuthStore } from '@/stores/login'
 import { getMemberMe } from '@/services/member'
 import { useUserStore } from '@/stores/user'
+import Cookies from 'js-cookie'
 
 export default function LoginCallbackPage() {
   const router = useRouter()
@@ -15,9 +16,12 @@ export default function LoginCallbackPage() {
   const { setUser } = useUserStore()
   const searchParams = useSearchParams()
 
-  const accessToken = searchParams.get('accessToken')
-  const refreshToken = searchParams.get('refreshToken')
+  const accessTokenParam = searchParams.get('accessToken')
+  const refreshTokenParam = searchParams.get('refreshToken')
   const errorCode = searchParams.get('errorCode')
+
+  const accessToken = Cookies.get('accessToken')
+  const refreshToken = Cookies.get('refreshToken')
 
   useEffect(() => {
     // 에러 처리
@@ -29,14 +33,14 @@ export default function LoginCallbackPage() {
     }
 
     // 토큰 없으면 로그인 페이지
-    if (!accessToken || !refreshToken) {
+    if (!accessTokenParam || !refreshTokenParam) {
       router.replace('/login')
       return
     }
 
     // 로그인 성공 시 쿠키 저장
-    setLogin(accessToken, refreshToken)
-  }, [accessToken, refreshToken, errorCode, router, setLogin])
+    setLogin(accessTokenParam, refreshTokenParam)
+  }, [accessTokenParam, refreshTokenParam, errorCode, router, setLogin])
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -49,8 +53,7 @@ export default function LoginCallbackPage() {
         router.replace('/login')
       }
     }
-
-    fetchUser()
+    if (accessToken && refreshToken) fetchUser()
   }, [accessToken, refreshToken, router, setUser])
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,25 +8,29 @@ export async function middleware(request: NextRequest) {
   let shouldRemoveCookies = false
 
   // 내 정보 API 호출로 accessToken 유효성 확인
-  try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/member/me`, {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    })
+  const checkValidToken = async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/member/me`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      })
 
-    const result = await res.json()
+      const result = await res.json()
 
-    if (result.result === 'SUCCESS') {
-      isAuthenticated = true
-    } else {
+      if (result.result === 'SUCCESS') {
+        isAuthenticated = true
+      } else {
+        shouldRemoveCookies = true
+      }
+    } catch (error) {
+      console.log('❌ Token 유효성 error:', error)
       shouldRemoveCookies = true
     }
-  } catch (error) {
-    console.log('❌ Token 유효성 error:', error)
-    shouldRemoveCookies = true
   }
+
+  if (accessToken) await checkValidToken()
 
   const isLoginPage = ['/login', '/login/callback'].includes(pathname)
   const isProtectedPage = ['/mypage', '/community'].some((prefix) => pathname.startsWith(prefix))


### PR DESCRIPTION
## 🐞 버그 수정

```typescript
// 내 정보 API 호출로 accessToken 유효성 확인
const checkValidToken = async () => {
  try {
    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/member/me`, {
      headers: {
        'Content-Type': 'application/json',
        Authorization: `Bearer ${accessToken}`,
      },
    })

    const result = await res.json()

    if (result.result === 'SUCCESS') {
      isAuthenticated = true
    } else {
      shouldRemoveCookies = true
    }
  } catch (error) {
    console.log('❌ Token 유효성 error:', error)
    shouldRemoveCookies = true
  }
}

if (accessToken) await checkValidToken()
```

- 로그인 시 액세스 토큰 없을 때도 checkToken() 을 타는 로직 수정
- `if (accessToken)`, `await` 추가하여 로직 보완

## 👀 관련 이슈 번호

- #83 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그인 콜백 처리 시 URL 파라미터에서 전달된 토큰과 쿠키에 저장된 토큰을 명확히 분리하여 처리하도록 개선되었습니다. 이로 인해 로그인 상태 및 사용자 정보 조회의 신뢰성이 향상되었습니다.

- **리팩터링**
  - 인증 미들웨어의 토큰 유효성 검사 로직이 내부 함수로 분리되어 코드 구조가 개선되었습니다.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->