### PR TITLE
[캘린더] 월별 데이터 호출 로직 수정 및 키링 이벤트 데이터 추가 (#97)

### DIFF
--- a/src/app/(full-layout)/(main)/components/WeeklyScheduleSection.tsx
+++ b/src/app/(full-layout)/(main)/components/WeeklyScheduleSection.tsx
@@ -3,11 +3,12 @@
 import SectionHeader from '@/app/(full-layout)/(main)/components/SectionHeader'
 import clsx from 'clsx'
 import dayjs from 'dayjs'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useAuthStore } from '@/stores/login'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { getWeeklySchedule } from '@/services/calendar'
+import { sortEvents } from '@/app/(full-layout)/calendar/util/sortEvents'
 import DayScheduleList from '@/app/(full-layout)/calendar/components/DayScheduleList'
 import { WeeklyScheduleResponseType } from '@/app/(full-layout)/calendar/types/calendarType'
 
@@ -50,7 +51,46 @@ export default function WeeklyScheduleSection() {
     }
   }, [data])
 
-  const selectedDay = days.find((d) => d.date === selectedDate)
+  // 선택된 날짜의 이벤트 데이터
+  const selectedDay = useMemo(() => {
+    const activeDay = days.find((d) => d.date === selectedDate)
+    if (!activeDay) return null
+
+    const kiringEventList = []
+
+    // 오픈 이벤트 날짜 추가
+    switch (activeDay.date) {
+      case '2025-06-27':
+        kiringEventList.push({
+          eventId: 9999,
+          eventType: 'NOTICE' as const,
+          title: '오늘은 키링 첫 오픈 날이에요!',
+          start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+          end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+          creatorName: null,
+        })
+        break
+      case '2025-07-04':
+        kiringEventList.push({
+          eventId: 9998,
+          eventType: 'NOTICE' as const,
+          title: '오늘은 QA 이벤트 마감일이에요!',
+          start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+          end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+          creatorName: null,
+        })
+        break
+    }
+
+    // 날짜 데이터 병합 및 정렬
+    const allEvnets = [...activeDay.events, ...kiringEventList]
+    const sortedEvents = sortEvents(allEvnets)
+
+    return {
+      ...activeDay,
+      events: sortedEvents,
+    }
+  }, [days, selectedDate])
 
   return (
     <section className="w-full bg-white pb-5">

--- a/src/app/(full-layout)/(main)/components/WeeklyScheduleSection.tsx
+++ b/src/app/(full-layout)/(main)/components/WeeklyScheduleSection.tsx
@@ -10,6 +10,7 @@ import { useQuery } from '@tanstack/react-query'
 import { getWeeklySchedule } from '@/services/calendar'
 import { sortEvents } from '@/app/(full-layout)/calendar/util/sortEvents'
 import DayScheduleList from '@/app/(full-layout)/calendar/components/DayScheduleList'
+import { KIRING_EVENT_LIST } from '@/app/(full-layout)/calendar/constants'
 import { WeeklyScheduleResponseType } from '@/app/(full-layout)/calendar/types/calendarType'
 
 const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일']
@@ -56,35 +57,18 @@ export default function WeeklyScheduleSection() {
     const activeDay = days.find((d) => d.date === selectedDate)
     if (!activeDay) return null
 
-    const kiringEventList = []
+    // 오픈 이벤트 데이터 필터링
+    const kiringEventList = KIRING_EVENT_LIST.filter((event) => {
+      const eventDate = dayjs(event.start).format('YYYY-MM-DD')
+      return eventDate === activeDay.date
+    }).map((event) => ({
+      ...event,
+      creatorName: null,
+    }))
 
-    // 오픈 이벤트 날짜 추가
-    switch (activeDay.date) {
-      case '2025-06-27':
-        kiringEventList.push({
-          eventId: 9999,
-          eventType: 'NOTICE' as const,
-          title: '오늘은 키링 첫 오픈 날이에요!',
-          start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
-          end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
-          creatorName: null,
-        })
-        break
-      case '2025-07-04':
-        kiringEventList.push({
-          eventId: 9998,
-          eventType: 'NOTICE' as const,
-          title: '오늘은 QA 이벤트 마감일이에요!',
-          start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
-          end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
-          creatorName: null,
-        })
-        break
-    }
-
-    // 날짜 데이터 병합 및 정렬
-    const allEvnets = [...activeDay.events, ...kiringEventList]
-    const sortedEvents = sortEvents(allEvnets)
+    // 이벤트 데이터 병합 및 정렬
+    const allEvents = [...activeDay.events, ...kiringEventList]
+    const sortedEvents = sortEvents(allEvents)
 
     return {
       ...activeDay,

--- a/src/app/(full-layout)/calendar/components/CalendarContents.tsx
+++ b/src/app/(full-layout)/calendar/components/CalendarContents.tsx
@@ -10,7 +10,7 @@ import { getCalendarSchedules } from '@/services/calendar'
 import DayScheduleList from '@/app/(full-layout)/calendar/components/DayScheduleList'
 import IcoToggle from '@/assets/ico-toggle.svg'
 import { sortEvents } from '@/app/(full-layout)/calendar/util/sortEvents'
-import { SCHEDULE_TYPE_KO } from '@/app/(full-layout)/calendar/constants'
+import { SCHEDULE_TYPE_KO, KIRING_EVENT_LIST } from '@/app/(full-layout)/calendar/constants'
 import { CalendarResponseType } from '@/app/(full-layout)/calendar/types/calendarType'
 import './react-calendar.css'
 
@@ -35,25 +35,9 @@ export default function CalendarContents() {
 
   useEffect(() => {
     if (isLogin) {
-      const kiringEventList: CalendarResponseType = [
-        {
-          eventId: 9999,
-          eventType: 'NOTICE' as const,
-          title: '오늘은 키링 첫 오픈 날이에요!',
-          start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
-          end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
-        },
-        {
-          eventId: 9998,
-          eventType: 'NOTICE' as const,
-          title: '오늘은 QA 이벤트 마감일이에요!',
-          start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
-          end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
-        },
-      ]
       const newCalendarRes: CalendarResponseType = calendarRes
-        ? [...calendarRes, ...kiringEventList]
-        : kiringEventList
+        ? [...calendarRes, ...KIRING_EVENT_LIST]
+        : KIRING_EVENT_LIST
       setMonthlyScheduleList(newCalendarRes)
     }
   }, [calendarRes, isLogin])

--- a/src/app/(full-layout)/calendar/components/CalendarContents.tsx
+++ b/src/app/(full-layout)/calendar/components/CalendarContents.tsx
@@ -9,6 +9,7 @@ import { useAuthStore } from '@/stores/login'
 import { getCalendarSchedules } from '@/services/calendar'
 import DayScheduleList from '@/app/(full-layout)/calendar/components/DayScheduleList'
 import IcoToggle from '@/assets/ico-toggle.svg'
+import { sortEvents } from '@/app/(full-layout)/calendar/util/sortEvents'
 import { SCHEDULE_TYPE_KO } from '@/app/(full-layout)/calendar/constants'
 import { CalendarResponseType } from '@/app/(full-layout)/calendar/types/calendarType'
 import './react-calendar.css'
@@ -17,10 +18,11 @@ export default function CalendarContents() {
   const [clickedDate, setClickedDate] = useState(dayjs().format('YYYY-MM-DD'))
   const [clickedYearMonth, setClickedYearMonth] = useState(dayjs().format('YYYY-MM'))
   const [clickedScheduleList, setClickedScheduleList] = useState<CalendarResponseType>([])
+  const [monthlyScheduleList, setMonthlyScheduleList] = useState<CalendarResponseType>([])
 
   const { isLogin } = useAuthStore()
 
-  const { data: monthlyScheduleList } = useQuery({
+  const { data: calendarRes } = useQuery<CalendarResponseType>({
     queryKey: ['calendar-schedules', clickedYearMonth],
     queryFn: () =>
       getCalendarSchedules({
@@ -32,10 +34,34 @@ export default function CalendarContents() {
   })
 
   useEffect(() => {
+    const kiringEventList: CalendarResponseType = [
+      {
+        eventId: 9999,
+        eventType: 'NOTICE' as const,
+        title: '오늘은 키링 첫 오픈 날이에요!',
+        start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+        end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+      },
+      {
+        eventId: 9998,
+        eventType: 'NOTICE' as const,
+        title: '오늘은 QA 이벤트 마감일이에요!',
+        start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+        end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+      },
+    ]
+    const newCalendarRes: CalendarResponseType = calendarRes
+      ? [...calendarRes, ...kiringEventList]
+      : kiringEventList
+    setMonthlyScheduleList(newCalendarRes)
+  }, [calendarRes])
+
+  useEffect(() => {
     const list = monthlyScheduleList?.filter((schedule) => {
       return dayjs(schedule.start).format('YYYY-MM-DD') === clickedDate
     })
-    setClickedScheduleList(list ?? [])
+    const sortedList = sortEvents(list || [])
+    setClickedScheduleList(sortedList)
   }, [clickedDate, monthlyScheduleList])
 
   return (
@@ -74,6 +100,9 @@ export default function CalendarContents() {
           }
           prev2Label={null}
           next2Label={null}
+          onActiveStartDateChange={({ activeStartDate }) => {
+            setClickedYearMonth(dayjs(activeStartDate).format('YYYY-MM'))
+          }}
           onClickDay={(value) => {
             setClickedDate(dayjs(value).format('YYYY-MM-DD'))
             setClickedYearMonth(dayjs(value).format('YYYY-MM'))
@@ -94,18 +123,18 @@ export default function CalendarContents() {
                   </>
                 )}
                 <div className="flex-row-center absolute bottom-1 h-2 w-full gap-1">
-                  {todaySchedulesList
+                  {sortEvents(todaySchedulesList || [])
                     ?.slice(0, 3)
                     ?.map(({ eventId, eventType }, idx) => (
                       <div
                         key={`${eventId}-${eventType}-${idx}`}
                         className={clsx(
                           'h-1 w-1 rounded-full',
+                          eventType === 'NOTICE' && 'bg-system-purple',
                           eventType === 'BIRTHDAY' && 'bg-system-yellow',
                           eventType === 'STUDY' && 'bg-system-green',
                           eventType === 'DINNER' && 'bg-system-blue',
                           eventType === 'HOLIDAY' && 'bg-system-red',
-                          eventType === 'NOTICE' && 'bg-system-purple',
                         )}
                       />
                     ))}

--- a/src/app/(full-layout)/calendar/components/CalendarContents.tsx
+++ b/src/app/(full-layout)/calendar/components/CalendarContents.tsx
@@ -34,27 +34,29 @@ export default function CalendarContents() {
   })
 
   useEffect(() => {
-    const kiringEventList: CalendarResponseType = [
-      {
-        eventId: 9999,
-        eventType: 'NOTICE' as const,
-        title: '오늘은 키링 첫 오픈 날이에요!',
-        start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
-        end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
-      },
-      {
-        eventId: 9998,
-        eventType: 'NOTICE' as const,
-        title: '오늘은 QA 이벤트 마감일이에요!',
-        start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
-        end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
-      },
-    ]
-    const newCalendarRes: CalendarResponseType = calendarRes
-      ? [...calendarRes, ...kiringEventList]
-      : kiringEventList
-    setMonthlyScheduleList(newCalendarRes)
-  }, [calendarRes])
+    if (isLogin) {
+      const kiringEventList: CalendarResponseType = [
+        {
+          eventId: 9999,
+          eventType: 'NOTICE' as const,
+          title: '오늘은 키링 첫 오픈 날이에요!',
+          start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+          end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+        },
+        {
+          eventId: 9998,
+          eventType: 'NOTICE' as const,
+          title: '오늘은 QA 이벤트 마감일이에요!',
+          start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+          end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+        },
+      ]
+      const newCalendarRes: CalendarResponseType = calendarRes
+        ? [...calendarRes, ...kiringEventList]
+        : kiringEventList
+      setMonthlyScheduleList(newCalendarRes)
+    }
+  }, [calendarRes, isLogin])
 
   useEffect(() => {
     const list = monthlyScheduleList?.filter((schedule) => {

--- a/src/app/(full-layout)/calendar/components/DayScheduleList.tsx
+++ b/src/app/(full-layout)/calendar/components/DayScheduleList.tsx
@@ -22,43 +22,41 @@ export default function DayScheduleList({
 }) {
   const { isLogin } = useAuthStore()
 
-  const renderSchedule = (schedule?: CalendarResponseItem) => {
+  const renderSchedule = (schedule?: CalendarResponseItem, index?: number) => {
     const type = schedule?.eventType || 'EMPTY'
     const title = schedule?.title || ''
     const day = dayjs(schedule?.start).format('D')
 
     const getStudyText = (title: string) => {
-      const [beName, feName] = title.split(',') ?? ','
-      const beText = beName ? `백엔드팀 ${beName}님, ` : ''
-      const feText = feName ? `프론트팀 ${feName}님` : ''
-      return `${beText}${feText} 팀스터디에요`
+      const [first, second] = title.trim().split(',') ?? ''
+      return `${first ? first + '님' : ''}${second ? ', ' + second + '님' : ''} 팀스터디에요`
     }
 
     const typeMap: Record<string, { icon: React.JSX.Element; title: string; desc: string }> = {
+      NOTICE: {
+        icon: <IcoNotice />,
+        title: title,
+        desc: '놓치지 말고 꼭 확인해주세요!',
+      },
       BIRTHDAY: {
         icon: <IcoBirthday />,
         title: `${title}님 생일이에요`,
         desc: '따뜻한 축하 한마디 남겨주세요',
+      },
+      DINNER: {
+        icon: <IcoDinner />,
+        title: `${title} 회식이에요`,
+        desc: '이번 주도 수고 했어요, 시원하게 짠!',
       },
       STUDY: {
         icon: <IcoStudy />,
         title: getStudyText(title),
         desc: '지식을 나누면 팀도 함께 성장해요',
       },
-      DINNER: {
-        icon: <IcoDinner />,
-        title: `${title}팀 회식이에요`,
-        desc: '이번 주도 수고 했어요, 시원하게 짠!',
-      },
       HOLIDAY: {
         icon: <IcoHoliday />,
         title: `${day}일은 휴일이에요`,
         desc: '충전 가득한 하루 보내세요',
-      },
-      NOTICE: {
-        icon: <IcoNotice />,
-        title: title,
-        desc: '놓치지 말고 꼭 확인해주세요!',
       },
       EMPTY: {
         icon: <IcoEmpty />,
@@ -70,11 +68,20 @@ export default function DayScheduleList({
     const { icon, title: itemTitle, desc } = typeMap[type]
 
     return (
-      <li key={`${schedule?.eventId}-${type}`} className="flex items-center gap-3">
+      <li key={`${type}-${schedule?.eventId}-${index}`} className="flex items-center gap-3">
         {icon}
+
         <p className="flex flex-col justify-center gap-1.5">
           <span className="body4-sb text-gray-800">{itemTitle}</span>
-          <span className="body5 text-purple-500">{desc}</span>
+          {[9998, 9999].includes(schedule?.eventId ?? -1) ? (
+            <span className="body5 text-purple-500">
+              {schedule?.eventId === 9999
+                ? '회사생활이 조금 더 특별해질 거예요 🎉'
+                : '제출하고 🎁 이벤트 상품 꼭 받아가세요!'}
+            </span>
+          ) : (
+            <span className="body5 text-purple-500">{desc}</span>
+          )}
         </p>
       </li>
     )
@@ -96,7 +103,7 @@ export default function DayScheduleList({
         <ul className="flex flex-col gap-4">
           {scheduleList
             ?.slice(0, maxLength ?? scheduleList.length)
-            ?.map((schedule) => renderSchedule(schedule))}
+            ?.map((schedule, index) => renderSchedule(schedule, index))}
         </ul>
       )}
     </>

--- a/src/app/(full-layout)/calendar/components/DayScheduleList.tsx
+++ b/src/app/(full-layout)/calendar/components/DayScheduleList.tsx
@@ -28,7 +28,7 @@ export default function DayScheduleList({
     const day = dayjs(schedule?.start).format('D')
 
     const getStudyText = (title: string) => {
-      const [first, second] = title.trim().split(',') ?? ''
+      const [first = '', second = ''] = title.trim().split(',')
       return `${first ? first + '님' : ''}${second ? ', ' + second + '님' : ''} 팀스터디에요`
     }
 

--- a/src/app/(full-layout)/calendar/constants.ts
+++ b/src/app/(full-layout)/calendar/constants.ts
@@ -1,7 +1,18 @@
+import { EventType } from '@/app/(full-layout)/calendar/types/calendarType'
+
 export const SCHEDULE_TYPE_KO = [
-  { id: 1, name: '생일', color: 'before:bg-system-yellow' },
-  { id: 2, name: '스터디', color: 'before:bg-system-green' },
+  { id: 1, name: '공지', color: 'before:bg-system-purple' },
+  { id: 2, name: '생일', color: 'before:bg-system-yellow' },
   { id: 3, name: '회식', color: 'before:bg-system-blue' },
-  { id: 4, name: '휴일', color: 'before:bg-system-red' },
-  { id: 5, name: '공지', color: 'before:bg-system-purple' },
+  { id: 4, name: '스터디', color: 'before:bg-system-green' },
+  { id: 5, name: '휴일', color: 'before:bg-system-red' },
 ] as const
+
+export const EVENT_TYPE_PRIORITY: Record<EventType, number> = {
+  NOTICE: 1,
+  BIRTHDAY: 2,
+  DINNER: 3,
+  STUDY: 4,
+  HOLIDAY: 5,
+  EMPTY: 6,
+} as const

--- a/src/app/(full-layout)/calendar/constants.ts
+++ b/src/app/(full-layout)/calendar/constants.ts
@@ -1,4 +1,5 @@
-import { EventType } from '@/app/(full-layout)/calendar/types/calendarType'
+import dayjs from '@/lib/dayjs'
+import { EventType, CalendarResponseType } from '@/app/(full-layout)/calendar/types/calendarType'
 
 export const SCHEDULE_TYPE_KO = [
   { id: 1, name: '공지', color: 'before:bg-system-purple' },
@@ -16,3 +17,20 @@ export const EVENT_TYPE_PRIORITY: Record<EventType, number> = {
   HOLIDAY: 5,
   EMPTY: 6,
 } as const
+
+export const KIRING_EVENT_LIST: CalendarResponseType = [
+  {
+    eventId: 9999,
+    eventType: 'NOTICE' as const,
+    title: '오늘은 키링 첫 오픈 날이에요!',
+    start: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+    end: dayjs('2025-06-27').format('YYYY-MM-DDTHH:mm:ss'),
+  },
+  {
+    eventId: 9998,
+    eventType: 'NOTICE' as const,
+    title: '오늘은 QA 이벤트 마감일이에요!',
+    start: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+    end: dayjs('2025-07-04').format('YYYY-MM-DDTHH:mm:ss'),
+  },
+]

--- a/src/app/(full-layout)/calendar/types/calendarType.ts
+++ b/src/app/(full-layout)/calendar/types/calendarType.ts
@@ -1,10 +1,11 @@
+export type EventType = 'NOTICE' | 'BIRTHDAY' | 'DINNER' | 'STUDY' | 'HOLIDAY' | 'EMPTY'
+
 export interface CalendarResponseItem {
   eventId: number | null
-  eventType: string
+  eventType: EventType
   title: string
-  start: Date
-  end: Date
-  creatorName: string | null
+  start: Date | string
+  end: Date | string
 }
 
 export type CalendarResponseType = CalendarResponseItem[]

--- a/src/app/(full-layout)/calendar/util/sortEvents.ts
+++ b/src/app/(full-layout)/calendar/util/sortEvents.ts
@@ -1,0 +1,14 @@
+import { EVENT_TYPE_PRIORITY } from '@/app/(full-layout)/calendar/constants'
+import { CalendarResponseType, EventType } from '@/app/(full-layout)/calendar/types/calendarType'
+
+const getEventPriority = (eventType: EventType): number => {
+  return EVENT_TYPE_PRIORITY[eventType as EventType] ?? EVENT_TYPE_PRIORITY['EMPTY']
+}
+
+export const sortEvents = (eventList: CalendarResponseType): CalendarResponseType => {
+  if (!eventList || !eventList.length) return eventList
+
+  return [...eventList].sort((a, b) => {
+    return getEventPriority(a.eventType) - getEventPriority(b.eventType)
+  })
+}


### PR DESCRIPTION
## 🚀 개선 사항

- 사용성 개선을 위한 로직 수정

## 🏗 작업 내용

![캘린더 페이지](https://github.com/user-attachments/assets/f5bff78a-3164-4c7d-a31a-8fede5309b90)

- 캘린더 월 이동 시 해당 월 데이터를 동적으로 API 호출하도록 로직 개선
- 팀스 출력 시 '~팀' 제외, 발표자 명수에 맞춰 텍스트 출력
- 생일 데이터 아이디 null 이슈 해결을 위한 unique key 값 수정
- 오픈/QA 이벤트 임시 데이터 하드코딩하여 캘린더 리스트에 추가
- 캘린더 이벤트 표시 순서 정립(공지→생일→회식→스터디→휴일) 및 sortEvents 함수 구현

## 👀 관련 이슈 번호

- #97 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 특정 날짜(2025년 6월 27일, 7월 4일)에 "공지" 이벤트가 자동으로 추가되어 일정에 표시됩니다.
  * 일정 목록이 이벤트 유형 우선순위에 따라 정렬되어 더욱 직관적으로 확인할 수 있습니다.
  * 달력에서 월 변경 시 해당 월의 일정이 자동으로 갱신됩니다.

* **버그 수정**
  * 일정 항목의 고유 키 생성 방식이 개선되어 중복 렌더링 문제를 방지합니다.

* **스타일**
  * "공지" 이벤트 유형의 색상이 올바르게 표시되도록 조건부 클래스 순서가 조정되었습니다.

* **기타**
  * 이벤트 타입 및 일정 데이터 타입이 명확하게 지정되어 데이터 일관성이 향상되었습니다.
  * 일정 제목 및 설명 표시 방식이 개선되어 가독성이 높아졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->