### PR TITLE
메인, 마이 프로필 / 입사일 기준 년도, 개월, 일자 없을때도 0으로 표기도록 수정

### DIFF
--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -45,9 +45,9 @@ export function formatElapsedDate(dateString: string, isMain?: boolean): string 
   const days = diffDays % 30
 
   const parts = []
-  if (years > 0) parts.push(isMain ? `${years}` : `${years}년`)
-  if (months > 0) parts.push(isMain ? `${months}` : `${months}개월`)
-  if (days > 0) parts.push(isMain ? `${days}` : `${days}일`)
+  parts.push(isMain ? `${years}` : `${years}년`)
+  parts.push(isMain ? `${months}` : `${months}개월`)
+  parts.push(isMain ? `${days}` : `${days}일`)
 
   if (isMain) {
     return parts


### PR DESCRIPTION
## 🚀 기능 추가 / 개선 사항
메인, 마이 프로필 / 입사일 기준 년도, 개월, 일자 없을때도 0으로 표기도록 수정
![2025-06-26_5 30 14](https://github.com/user-attachments/assets/0d4d2fbe-c271-466c-b30c-0d758bfc2a64)

## 🏗 작업 내용 | 🔍 해결 방법 | 🧐 주요 변경 사항

- 메인, 마이 프로필 / 입사일 기준 년도, 개월, 일자 없을때도 0으로 표기도록 수정

