### PR TITLE
[메인페이지] UI/UX 개선 및 환경 변수 관리 리팩토링 (#114)

### DIFF
--- a/src/app/(full-layout)/(main)/components/WeeklyScheduleSection.tsx
+++ b/src/app/(full-layout)/(main)/components/WeeklyScheduleSection.tsx
@@ -26,6 +26,8 @@ export default function WeeklyScheduleSection() {
   const { data } = useQuery({
     queryKey: ['weeklySchedule'],
     queryFn: () => getWeeklySchedule(),
+    enabled: isLogin,
+    refetchOnWindowFocus: false,
   })
   const router = useRouter()
 

--- a/src/app/(full-layout)/(main)/components/introSection/IntroSection.tsx
+++ b/src/app/(full-layout)/(main)/components/introSection/IntroSection.tsx
@@ -104,7 +104,7 @@ export default function IntroSection({ visible = true, onClose }: IntroSectionPr
   return (
     <section
       className={clsx(
-        'full-width relative min-h-[200px] bg-gradient-to-b from-white from-[-10%] to-purple-100 py-3 transition-all duration-300 ease-in-out',
+        'full-width relative min-h-[200px] bg-gradient-to-b from-white from-[-20%] to-purple-100 py-3 transition-all duration-300 ease-in-out',
         closing ? 'pointer-events-none -translate-y-6 opacity-0' : 'translate-y-0 opacity-100',
       )}
     >

--- a/src/app/(full-layout)/(main)/components/memberSection/MemberSection.tsx
+++ b/src/app/(full-layout)/(main)/components/memberSection/MemberSection.tsx
@@ -11,8 +11,20 @@ import { TEAMS } from '@/app/(full-layout)/constants'
 import { useAuthStore } from '@/stores/login'
 import { useRouter } from 'next/navigation'
 import { useUserStore } from '@/stores/user'
-import LoadingSpinner from '@/components/ui/LoadingSpinner'
 import { Member } from '@/app/(full-layout)/(main)/types/member'
+
+// 스켈레톤 멤버 컴포넌트
+function MemberSkeleton() {
+  return (
+    <div className="scroll-hidden flex h-19 items-start justify-start gap-6 overflow-x-scroll">
+      {Array.from({ length: 2 }).map((_, idx) => (
+        <div key={`skeleton-${idx}`} className="flex-shrink-0">
+          <div className="aspect-square h-13 w-13 animate-pulse rounded-full bg-gray-300" />
+        </div>
+      ))}
+    </div>
+  )
+}
 
 export default function MemberSection() {
   const router = useRouter()
@@ -57,9 +69,9 @@ export default function MemberSection() {
         )}
 
         {(isLoading || error) && (
-          <div className="flex-row-center mx-4 h-19">
+          <div className={clsx('mx-4 h-19', isLoading ? 'flex' : 'flex-row-center')}>
             {isLoading ? (
-              <LoadingSpinner />
+              <MemberSkeleton />
             ) : (
               <span className="body4 text-red-500">데이터를 불러오는데 실패했습니다.</span>
             )}

--- a/src/app/(header-layout)/place/components/restaurant/RestaurantContents.tsx
+++ b/src/app/(header-layout)/place/components/restaurant/RestaurantContents.tsx
@@ -362,7 +362,7 @@ export default function RestaurantContents() {
           {!isSheetExpanded && (
             <button
               type="button"
-              className="mx-auto my-3 block h-1 w-20 rounded-sm bg-gray-200"
+              className="mx-auto my-3 block h-1 w-30 rounded-sm bg-gray-200"
               onClick={toggleSheetPosition}
             >
               <span className="sr-only">매장 목록 보기</span>


### PR DESCRIPTION
## 🏗 작업 내용

- 플레이스 바텀시트 상단 '목록보기' 버튼 width 확장
- 메인페이지 멤버 섹션에 스켈레톤 UI 추가
- 메인페이지 스크롤 위치에 따라 헤더 배경색 동적 변경

## 👀 관련 이슈 번호

- #114 
