### PR TITLE
[hotfix] 오늘 받은 종이비행기가 있을 때만 팝업 노출되도록 조건 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+![스터디 1](https://github.com/user-attachments/assets/670fc103-bf06-46e6-817f-643c0c9d4d8d)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,18 +1,21 @@
 import type { NextConfig } from 'next'
-
-const withPWA = require('next-pwa')({
-  dest: 'public',
-  register: true,
-  skipWaiting: true,
-})
+import withPWA from 'next-pwa'
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['pub-cf3b9667253a490495a16433a99bd7ca.r2.dev'],
     remotePatterns: [
-      { protocol: 'https', hostname: '**' },
-      { protocol: 'http', hostname: '**' },
+      // 네이버 이미지
+      {
+        protocol: 'https',
+        hostname: '*.pstatic.net',
+      },
+      // 클라우드 플레어 R2 스토리지
+      {
+        protocol: 'https',
+        hostname: 'pub-cf3b9667253a490495a16433a99bd7ca.r2.dev',
+      },
     ],
+    unoptimized: true,
   },
   turbopack: {
     rules: {
@@ -31,4 +34,8 @@ const nextConfig: NextConfig = {
   },
 }
 
-export default withPWA(nextConfig)
+export default withPWA({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+})(nextConfig)

--- a/src/types/next-pwa.d.ts
+++ b/src/types/next-pwa.d.ts
@@ -1,0 +1,22 @@
+// src/types/next-pwa.d.ts
+declare module 'next-pwa' {
+  import { NextConfig } from 'next'
+
+  interface PWAConfig {
+    dest?: string
+    register?: boolean
+    skipWaiting?: boolean
+    disable?: boolean
+    sw?: string
+    runtimeCaching?: Array<{
+      urlPattern: RegExp | string
+      handler: string
+      options?: Record<string, unknown>
+    }>
+    buildExcludes?: RegExp[]
+    fallbacks?: Record<string, string>
+  }
+
+  function withPWA(config: PWAConfig): (nextConfig: NextConfig) => NextConfig
+  export default withPWA
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,13 @@
     },
     "types": ["kakao.maps.d.ts"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "types/**/*.d.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "types/**/*.d.ts",
+    "src/types/**/*.d.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- todayPlane.hasTodayReceived가 true인 경우에만 팝업 노출 로직을 타도록 조건 분기 수정

## 🐞 버그 수정

- 기존 readPlane 데이터 유무만으로 판단하여, 오늘 받은 편지가 아니 더라도 팝업이 노출되는 문제
- todayPlane.hasTodayReceived가 true일 때 받은 편지 팝업 노출 로직 타도록 수정 

## 👀 관련 이슈 번호

- #93 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 오늘 비행기 수신 여부에 따라 "받은 비행기" 팝업이 더 정확하게 표시되도록 개선되었습니다.  
  * 팝업이 오늘 닫혔는지 확인하여 불필요한 팝업 노출이 방지됩니다.

* **기타**
  * PWA 설정이 업데이트되어 앱의 오프라인 경험과 이미지 로딩이 최적화되었습니다.
  * 타입스크립트 설정에 새로운 선언 파일 경로가 추가되어 개발 환경이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->