### PR TITLE
[플레이스] Vercel Image 402 Payment Error (#119)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,18 +1,21 @@
 import type { NextConfig } from 'next'
-
-const withPWA = require('next-pwa')({
-  dest: 'public',
-  register: true,
-  skipWaiting: true,
-})
+import withPWA from 'next-pwa'
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['pub-cf3b9667253a490495a16433a99bd7ca.r2.dev'],
     remotePatterns: [
-      { protocol: 'https', hostname: '**' },
-      { protocol: 'http', hostname: '**' },
+      // 네이버 이미지
+      {
+        protocol: 'https',
+        hostname: '*.pstatic.net',
+      },
+      // 클라우드 플레어 R2 스토리지
+      {
+        protocol: 'https',
+        hostname: 'pub-cf3b9667253a490495a16433a99bd7ca.r2.dev',
+      },
     ],
+    unoptimized: true,
   },
   turbopack: {
     rules: {
@@ -31,4 +34,8 @@ const nextConfig: NextConfig = {
   },
 }
 
-export default withPWA(nextConfig)
+export default withPWA({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+})(nextConfig)

--- a/src/types/next-pwa.d.ts
+++ b/src/types/next-pwa.d.ts
@@ -1,0 +1,22 @@
+// src/types/next-pwa.d.ts
+declare module 'next-pwa' {
+  import { NextConfig } from 'next'
+
+  interface PWAConfig {
+    dest?: string
+    register?: boolean
+    skipWaiting?: boolean
+    disable?: boolean
+    sw?: string
+    runtimeCaching?: Array<{
+      urlPattern: RegExp | string
+      handler: string
+      options?: Record<string, unknown>
+    }>
+    buildExcludes?: RegExp[]
+    fallbacks?: Record<string, string>
+  }
+
+  function withPWA(config: PWAConfig): (nextConfig: NextConfig) => NextConfig
+  export default withPWA
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,13 @@
     },
     "types": ["kakao.maps.d.ts"]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "types/**/*.d.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    "types/**/*.d.ts",
+    "src/types/**/*.d.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 🐞 버그 수정 및 개선 사항

- next.config.ts의 images에 `unoptimized: true` 설정 추가
- next.config.js ES module과 CommonJS 혼용 이슈 해결하여 ES module 방식으로 통합

<br />

## 🧐 주요 변경 사항

### 🐛 발생한 에러

![Image](https://github.com/user-attachments/assets/738b1b25-5e27-46f7-b5ce-ae03e666a515)

- 플레이스 진입 후 페이지 뷰를 Narrow Card → Wide Card로 변경 시 이미지가 부분 미노출되며 콘솔에 402 에러 발생

<br />

### 🔍 발생 원인

![402-vercel](https://github.com/user-attachments/assets/dba40e85-84a9-4223-b71f-6dcef9e8c60c)

- 프로젝트가 Vercel Hobby 플랜으로 배포되어 이미지 최적화 한도 초과
- Hobby 플랜은 월 1,000개의 소스 이미지 까지만 무료 최적화 제공
- 한도 초과 시 새로운 이미지들은 402 Payment Required 에러 반환
- Vercel 공식문서 링크: https://vercel.com/docs/image-optimization/limits-and-pricing#hobby

<br />

### 💡 해결 방법

```typescript
const nextConfig: NextConfig = {
  images: {
    unoptimized: true,
  },
```

- next.config.js에 `unoptimized: true` 설정
- 이미지가 최적화 파이프라인을 우회하여 원본 그대로 제공됨
- 따라서 소스 이미지 카운트가 0이 되어 월 한도에 영향을 주지 않음
- 참고 링크: https://stackoverflow.com/questions/77772240/http-get-image-402-payment-required

<br />

### 🤔 이미지 최적화 비활성화 시 영향

- 한도 초과 에러는 해결되지만, WebP, AVIF 등 효율적 포맷 사용 불가함
    → 현재 프로젝트에서는 svg, jpg, png만 사용 중
- 작은 화면에서도 큰 이미지가 로드되어 파일 크기 증가, 데이터 소비 상대적으로 증가
    → DB에 외부 URL을 저장하고 프론트로 가져오는 방식이라, 최적화 방법에 대해 추가 논의 필요

<br />

## 👀 관련 이슈 번호

- #119 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * PWA 설정이 개선되어 이미지 호스팅 도메인 관리와 최적화 옵션이 업데이트되었습니다.

* **문서화**
  * PWA 관련 타입 선언이 추가되어 타입스크립트 환경에서 더 안전하게 사용할 수 있습니다.

* **잡무**
  * 타입 선언 파일의 빌드 포함 범위가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->