### PR TITLE
[공통] 운영/개발계 배포 URL 분리 (#123)

### DIFF
--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -30,7 +30,6 @@ jobs:
           echo "Current branch: ${{ github.ref_name }}"
           git remote -v
 
-      # 🔧 토큰 유효성 확인 추가
       - name: Verify token
         run: |
           if [ -z "${{ secrets.KIRING_DEV_GITHUB_TOKEN }}" ]; then
@@ -38,18 +37,50 @@ jobs:
             exit 1
           else
             echo "✅ Token is available"
+            # 토큰 길이 확인 (마스킹)
+            echo "Token length: ${#GITHUB_TOKEN}"
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
 
-      - name: Add remote-url
+      - name: Configure Git
         run: |
-          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend
-          git config user.name kiring-dev
-          git config user.email kiring.dev@gmail.com
+          git config user.name "kiring-dev"
+          git config user.email "kiring.dev@gmail.com"
+
+      - name: Configure remote repository
+        run: |
+          # 기존 remote 제거 (있다면)
+          git remote remove forked-repo 2>/dev/null || true
+
+          # Personal Access Token을 사용한 remote 추가
+          git remote add forked-repo https://${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend.git
+
+          # Remote 확인
+          git remote -v
+
+      - name: Check repository status
+        run: |
+          echo "Current branch: $(git branch --show-current)"
+          echo "Remote branches:"
+          git branch -r
+          echo "Latest commit:"
+          git log --oneline -1
 
       - name: Push changes to forked-repo
         run: |
-          git push -f forked-repo ${{ github.ref_name }}
+          echo "Pushing ${{ github.ref_name }} to forked repository..."
+          git push -f forked-repo ${{ github.ref_name }} || {
+            echo "❌ Push failed. Checking remote status..."
+            git remote -v
+            echo "Current branch status:"
+            git status
+            exit 1
+          }
+          echo "✅ Successfully pushed to forked repository"
 
       - name: Clean up
+        if: always()
         run: |
-          git remote remove forked-repo
+          git remote remove forked-repo 2>/dev/null || true
+          echo "✅ Cleanup completed"

--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -1,7 +1,8 @@
-name: Synchronize develop to forked repo
+name: Synchronize branches to forked repo
 on:
   push:
     branches:
+      - main
       - develop
 
 jobs:
@@ -11,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout develop
+      - name: Checkout current branch
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
           fetch-depth: 0
-          ref: develop
+          ref: ${{ github.ref_name }}
 
       - name: Add remote-url
         run: |
-          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend-develop
+          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend
           git config user.name kiring-dev
           git config user.email kiring.dev@gmail.com
 
       - name: Push changes to forked-repo
         run: |
-          git push -f forked-repo develop
+          git push -f forked-repo ${{ github.ref_name }}
 
       - name: Clean up
         run: |

--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Add remote-url
         run: |
-          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend-develop
+          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend
           git config user.name kiring-dev
           git config user.email kiring.dev@gmail.com
 

--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
@@ -29,6 +28,16 @@ jobs:
           echo "Current repository: ${{ github.repository }}"
           echo "Current branch: ${{ github.ref_name }}"
           git remote -v
+
+      # 🔧 토큰 유효성 확인 추가
+      - name: Verify token
+        run: |
+          if [ -z "${{ secrets.KIRING_DEV_GITHUB_TOKEN }}" ]; then
+            echo "❌ KIRING_DEV_GITHUB_TOKEN is not set"
+            exit 1
+          else
+            echo "✅ Token is available"
+          fi
 
       - name: Add remote-url
         run: |

--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -7,8 +7,9 @@ on:
       - develop
 
 permissions:
-  contents: read
-  actions: read
+  contents: write
+  pull-requests: write
+  actions: write
 
 jobs:
   sync:

--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -1,15 +1,8 @@
-name: Synchronize branches to forked repo
-
+name: Synchronize develop to forked repo
 on:
   push:
     branches:
-      - main
       - develop
-
-permissions:
-  contents: write
-  pull-requests: write
-  actions: write
 
 jobs:
   sync:
@@ -18,69 +11,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout current branch
+      - name: Checkout develop
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
           fetch-depth: 0
-          ref: ${{ github.ref_name }}
+          ref: develop
 
-      - name: Debug info
+      - name: Add remote-url
         run: |
-          echo "Current repository: ${{ github.repository }}"
-          echo "Current branch: ${{ github.ref_name }}"
-          git remote -v
-
-      - name: Verify token
-        run: |
-          if [ -z "${{ secrets.KIRING_DEV_GITHUB_TOKEN }}" ]; then
-            echo "❌ KIRING_DEV_GITHUB_TOKEN is not set"
-            exit 1
-          else
-            echo "✅ Token is available"
-            # 토큰 길이 확인 (마스킹)
-            echo "Token length: ${#GITHUB_TOKEN}"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
-
-      - name: Configure Git
-        run: |
-          git config user.name "kiring-dev"
-          git config user.email "kiring.dev@gmail.com"
-
-      - name: Configure remote repository
-        run: |
-          # 기존 remote 제거 (있다면)
-          git remote remove forked-repo 2>/dev/null || true
-
-          # Personal Access Token을 사용한 remote 추가
-          git remote add forked-repo https://${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend.git
-
-          # Remote 확인
-          git remote -v
-
-      - name: Check repository status
-        run: |
-          echo "Current branch: $(git branch --show-current)"
-          echo "Remote branches:"
-          git branch -r
-          echo "Latest commit:"
-          git log --oneline -1
+          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend-develop
+          git config user.name kiring-dev
+          git config user.email kiring.dev@gmail.com
 
       - name: Push changes to forked-repo
         run: |
-          echo "Pushing ${{ github.ref_name }} to forked repository..."
-          git push -f forked-repo ${{ github.ref_name }} || {
-            echo "❌ Push failed. Checking remote status..."
-            git remote -v
-            echo "Current branch status:"
-            git status
-            exit 1
-          }
-          echo "✅ Successfully pushed to forked repository"
+          git push -f forked-repo develop
 
       - name: Clean up
-        if: always()
         run: |
-          git remote remove forked-repo 2>/dev/null || true
-          echo "✅ Cleanup completed"
+          git remote remove forked-repo

--- a/.github/workflows/develop_sync_fork.yml
+++ b/.github/workflows/develop_sync_fork.yml
@@ -1,9 +1,14 @@
 name: Synchronize branches to forked repo
+
 on:
   push:
     branches:
       - main
       - develop
+
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   sync:
@@ -18,6 +23,12 @@ jobs:
           token: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
           fetch-depth: 0
           ref: ${{ github.ref_name }}
+
+      - name: Debug info
+        run: |
+          echo "Current repository: ${{ github.repository }}"
+          echo "Current branch: ${{ github.ref_name }}"
+          git remote -v
 
       - name: Add remote-url
         run: |

--- a/.github/workflows/main_sync_fork.yml
+++ b/.github/workflows/main_sync_fork.yml
@@ -1,0 +1,33 @@
+name: Synchronize main to forked repo
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    if: github.repository == 'kitworks-kiring/kiring-frontend'
+    name: Sync forked repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.KIRING_DEV_GITHUB_TOKEN }}
+          fetch-depth: 0
+          ref: main
+
+      - name: Add remote-url
+        run: |
+          git remote add forked-repo https://kiring-dev:${{ secrets.KIRING_DEV_GITHUB_TOKEN }}@github.com/kiring-dev/kiring-frontend
+          git config user.name kiring-dev
+          git config user.email kiring.dev@gmail.com
+
+      - name: Push changes to forked-repo
+        run: |
+          git push -f forked-repo main
+
+      - name: Clean up
+        run: |
+          git remote remove forked-repo

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "productionBranch": "main"
+  }
+}


### PR DESCRIPTION
## 🚀 기능 추가 / 개선 사항

- 운영/개발계 배포 URL 분리
- main 브랜치 배포용 repo와 sync fork 자동화 추가

## 🏗 작업 내용 | 🔍 해결 방법 | 🧐 주요 변경 사항

- [x] vercel.json 설정
- [x] develop 브랜치 배포 시 `kiring-develop.vercel.app`, main 브랜치 배포 시 `kiring.vercel.app` 배포

## 👀 관련 이슈 번호

- #123 
