### PR TITLE
[버그 수정 ] postcss.config.mjs 삭제 설정 중복 및 충돌 방지

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,0 @@
-const config = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};
-
-export default config;


### PR DESCRIPTION
## 🐞 버그 수정

- 배포 환경에서 `@tailwindcss/postcss` 관련 모듈 에러 발생
- 원인: `postcss.config.js`와 `postcss.config.mjs` 중복으로 인한 Turbopack 충돌 가능성
- 조치: `.mjs` 파일 제거하고 `.js`만 유지

## 🔍 해결 방법

- postcss 설정 파일을 `.js` 하나로 통일
- `.js`에서는 `@tailwindcss/postcss` 이름을 유지하여 로컬 및 배포 환경 모두에서 정상 작동 확인

## 👀 관련 이슈 번호

- #127 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PostCSS 구성 파일이 삭제되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->